### PR TITLE
disable things when status is inactive

### DIFF
--- a/src/AddNewRow.js
+++ b/src/AddNewRow.js
@@ -7,7 +7,6 @@ export const AddNewRow = ({
   handleNameUpdate,
   name,
 }) => {
-  console.log("what i'm passing to addnewrow", dates);
   const handleClick = (e) => {
     let newArray = [];
     let targetDate = e.target.name ?? e.target.htmlFor;

--- a/src/AdminPage.js
+++ b/src/AdminPage.js
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { getSingleAdminEvent, closeEvent, deleteEvent } from "./firebase";
 import { useLoaderData, Await, defer, useAsyncValue } from "react-router-dom";
-import { Button, Stack, Modal } from "react-bootstrap";
+import { Button, Stack, Modal, Alert } from "react-bootstrap";
 import { DateTable } from "./DateTable";
 import { EmptyEvent } from "./EmptyEvent";
 import { reverseObject } from "./util";
@@ -22,6 +22,7 @@ const AdminChild = () => {
   const [shareUrlVisible, setShareUrlVisible] = useState(false);
   const [closeModalVisible, setCloseModalVisible] = useState(false);
   const [deleteModalVisible, setDeleteModalVisible] = useState(false);
+  const [successMessage, setSuccessMessage] = useState("");
   const navigate = useNavigate();
 
   const toggleShare = () => {
@@ -31,6 +32,7 @@ const AdminChild = () => {
   const toggleClose = () => {
     setCloseModalVisible(!closeModalVisible);
     setDeleteModalVisible(false);
+    setSuccessMessage("Noodle successfully closed.");
   };
 
   const toggleDelete = () => {
@@ -58,7 +60,7 @@ const AdminChild = () => {
   return (
     <>
       <h1>{finalAdminEvent.eventname}</h1>
-
+      {successMessage && <Alert variant="success">{successMessage}</Alert>}
       <div>
         This is your admin page for your Nood. You can visit this page at any
         time by visiting this url: {`${baseUrl}/admin/${finalAdminEvent.admin}`}
@@ -68,27 +70,29 @@ const AdminChild = () => {
         Your Nood is currently{" "}
         {finalAdminEvent.status.toUpperCase() ?? "Unknown"}.{" "}
       </div>
+
+      {shareUrlVisible && (
+        <>
+          <div>Share this link with your friends.</div>
+          <input type="text" value={`${baseUrl}/event/${eventKey}`} disabled />
+          <Button variant="secondary" onClick={copyLink}>
+            Copy Link
+          </Button>
+        </>
+      )}
+
       <div>
         From here you can:
-        <Stack>
+        <Stack direction="horizontal" gap={3}>
           <Button variant="primary" onClick={toggleShare}>
             Share your Nood
           </Button>
-          {shareUrlVisible && (
-            <>
-              <div>Share this link with your friends.</div>
-              <input
-                type="text"
-                value={`${baseUrl}/event/${eventKey}`}
-                disabled
-              />
-              <Button variant="secondary" onClick={copyLink}>
-                Copy Link
-              </Button>
-            </>
-          )}
-          <Button variant="primary" onClick={toggleClose}>
-            Close your Nood
+          <Button
+            variant="primary"
+            onClick={toggleClose}
+            disabled={finalAdminEvent.status === "inactive"}
+          >
+            Close Your Nood
           </Button>
           <Button variant="primary" onClick={toggleDelete}>
             Delete your Nood

--- a/src/EventPage.js
+++ b/src/EventPage.js
@@ -5,7 +5,7 @@ import { reverseObject, convertTimeStampToDate } from "./util";
 import { AddNewRow } from "./AddNewRow";
 import { useNavigate } from "react-router";
 import { submitPayload } from "./firebase/index";
-import { Button, Table, Stack } from "react-bootstrap";
+import { Button, Table, Stack, Alert } from "react-bootstrap";
 
 import {
   useLoaderData,
@@ -78,6 +78,9 @@ const EventChild = () => {
     <>
       <h1>{resolvedSingleEvent.eventname ?? "Untitled Event"}</h1>
       <h2>{resolvedSingleEvent.eventDesc ?? ""}</h2>
+      {resolvedSingleEvent.status === "inactive" && (
+        <Alert variant="warning">This Noodle is closed.</Alert>
+      )}
       <Stack>
         <form>
           <Table responsive="lg" bordered>
@@ -97,21 +100,25 @@ const EventChild = () => {
                   eventUUID={params.eventUUID}
                 />
               )}
-              <AddNewRow
-                dates={datesArray}
-                name={name}
-                handleNameUpdate={handleNameUpdate}
-                availableDates={availableDates}
-                setAvailableDates={setAvailableDates}
-              />
+              {resolvedSingleEvent.status === "active" && (
+                <AddNewRow
+                  dates={datesArray}
+                  name={name}
+                  handleNameUpdate={handleNameUpdate}
+                  availableDates={availableDates}
+                  setAvailableDates={setAvailableDates}
+                />
+              )}
             </tbody>
           </Table>
 
-          <div id="submitButtonContainer">
-            <Button variant="primary" onClick={handleSubmit}>
-              Submit
-            </Button>
-          </div>
+          {resolvedSingleEvent.status === "active" && (
+            <div id="submitButtonContainer">
+              <Button variant="primary" onClick={handleSubmit}>
+                Submit
+              </Button>
+            </div>
+          )}
         </form>
       </Stack>
     </>


### PR DESCRIPTION
When a Noodle is closed, it should not accept new responses, and the close button should be disabled. This accomplishes that.