### PR TITLE
delete noods past their expiration date

### DIFF
--- a/src/EmptyEvent.js
+++ b/src/EmptyEvent.js
@@ -4,6 +4,7 @@ import { Stack, Table, Button } from "react-bootstrap";
 import { convertTimeStampToDate } from "./util";
 
 export const EmptyEvent = ({ dates }) => {
+  const datesArray = Object.keys(dates);
   return (
     <>
       <Stack>
@@ -14,7 +15,7 @@ export const EmptyEvent = ({ dates }) => {
           <tbody>
             <tr>
               <td></td>
-              {dates.map((date) => {
+              {datesArray.map((date) => {
                 return <td key={date}>{convertTimeStampToDate(date)}</td>;
               })}
             </tr>

--- a/src/firebase/index.js
+++ b/src/firebase/index.js
@@ -68,7 +68,7 @@ export const submitNewEvent = (payload) => {
   const queryRef = query(
     dbRef,
     orderByChild("deleteAt"),
-    endAt(Math.floor(Date.now() / 1000) - 60 * 60 * 24 * 30)
+    endAt(Math.floor(Date.now() / 1000))
   );
   get(queryRef).then((snapshot) => {
     if (snapshot.exists()) {

--- a/src/firebase/index.js
+++ b/src/firebase/index.js
@@ -8,6 +8,7 @@ import {
   query,
   orderByChild,
   endAt,
+  startAt,
   limitToLast,
   update,
   remove,
@@ -61,6 +62,23 @@ export const submitNewEvent = (payload) => {
     status: "active",
     created: Date.now(),
     deleteAt: payload.deleteAt,
+  });
+  //perform housekeeping on db
+  const dbRef = ref(db, "event");
+  const queryRef = query(
+    dbRef,
+    orderByChild("deleteAt"),
+    endAt(Math.floor(Date.now() / 1000) - 60 * 60 * 24 * 30)
+  );
+  get(queryRef).then((snapshot) => {
+    if (snapshot.exists()) {
+      console.log(snapshot.val());
+      const keysToDelete = Object.keys(snapshot.val());
+      for (let key of keysToDelete) {
+        const singleEventRef = ref(db, "event/" + key);
+        return remove(singleEventRef);
+      }
+    }
   });
 };
 

--- a/src/firebase/index.js
+++ b/src/firebase/index.js
@@ -72,7 +72,6 @@ export const submitNewEvent = (payload) => {
   );
   get(queryRef).then((snapshot) => {
     if (snapshot.exists()) {
-      console.log(snapshot.val());
       const keysToDelete = Object.keys(snapshot.val());
       for (let key of keysToDelete) {
         const singleEventRef = ref(db, "event/" + key);


### PR DESCRIPTION
When a new event is created, search the DB for events whose expiration dates have passed, and delete them.
This will work unless I messed up the timestamp conversion again.