### PR TITLE
only return exact match

### DIFF
--- a/src/firebase/index.js
+++ b/src/firebase/index.js
@@ -92,8 +92,10 @@ export const getSingleAdminEvent = (eventID) => {
     if (snapshot.exists()) {
       const eventKey = Object.keys(snapshot.val());
       const eventWeWant = snapshot.val()[eventKey];
-      if (eventWeWant.deleteAt >= Math.floor(Date.now() / 1000)) {
-        console.log(snapshot.val()[eventKey]);
+      if (
+        eventWeWant.deleteAt >= Math.floor(Date.now() / 1000) &&
+        eventWeWant.admin === eventID
+      ) {
         return [snapshot.val()[eventKey], eventKey];
       }
       console.log(eventWeWant.deleteAt, Math.floor(Date.now() / 1000));


### PR DESCRIPTION
LOL so with firebase if you search by non-primary-key it seems the default behavior is to return the closest match. (Or I'm using their SDK wrong, which is totally possible.)
Anyway, since the "secret" admin UUID is not a primary key, that means that typing in an incorrect admin UUID would take you to the admin page for the event with the closest-match UUID.
This is obviously not ideal behavior, so I fixed it!