### PR TITLE
add location on event page

### DIFF
--- a/src/EventPage.js
+++ b/src/EventPage.js
@@ -105,6 +105,14 @@ const EventChild = () => {
       {resolvedSingleEvent.eventDesc && (
         <h2>{resolvedSingleEvent.eventDesc}</h2>
       )}
+      {resolvedSingleEvent.eventLocation && (
+        <>
+          <p>
+            <span className="h4">Location:</span>{" "}
+            {resolvedSingleEvent.eventLocation}
+          </p>
+        </>
+      )}
       {!resolvedSingleEvent.active && (
         <Alert variant="warning">This Noodle is closed.</Alert>
       )}


### PR DESCRIPTION
The event page never actually showed the location of the event.
I'm not sold on the styling here but it'll do for now?
I hope @eggchan notices how much I'm trying to be like her in terms of accessibility