### PR TITLE
move email payload to backend

### DIFF
--- a/src/Create.js
+++ b/src/Create.js
@@ -92,7 +92,7 @@ export const Create = () => {
             value={eventName}
             onChange={(e) => setEventName(e.target.value)}
             required
-            maxlength="100"
+            maxLength="100"
           />
         </Form.Group>
         <Form.Group controlId="eventDesc">
@@ -101,7 +101,7 @@ export const Create = () => {
             type="text"
             value={eventDesc}
             onChange={(e) => setEventDesc(e.target.value)}
-            maxlength="100"
+            maxLength="100"
           />
         </Form.Group>
         <Form.Group controlId="eventLocation">
@@ -111,7 +111,7 @@ export const Create = () => {
             value={eventLocation}
             placeholder="Where's your Nood"
             onChange={(e) => setEventLocation(e.target.value)}
-            maxlength="100"
+            maxLength="100"
           />
         </Form.Group>
         <Form.Group controlId="hostName">
@@ -122,7 +122,7 @@ export const Create = () => {
             placeholder="Your name; no impastas, please"
             onChange={(e) => setHostName(e.target.value)}
             required
-            maxlength="100"
+            maxLength="100"
           />
         </Form.Group>
         <Form.Group controlId="hostContact">
@@ -136,7 +136,7 @@ export const Create = () => {
             value={hostEmail}
             placeholder="you@mail.com"
             onChange={(e) => setHostEmail(e.target.value)}
-            maxlength="100"
+            maxLength="100"
           />
         </Form.Group>
         <Form.Group controlId="dates">

--- a/src/sg_helpers/index.js
+++ b/src/sg_helpers/index.js
@@ -2,24 +2,11 @@ export const sendResponseEmail = (vars) => {
   //todo DRY out the param builder
   const fullURL = `${process.env.REACT_APP_BASE_URL}/admin/${vars.admin}`;
   var params = {
-    from: {
-      email: "noodle@noodleapp.cool",
-    },
-    personalizations: [
-      {
-        to: [{ email: vars.hostEmail }],
-        dynamic_template_data: {
-          name: vars.hostName,
-          eventName: vars.eventName,
-          eventAdminUrl: fullURL,
-          respondee: vars.respondee,
-        },
-      },
-    ],
-    template_id: "d-6e89baf471ab478682b2757a40fbe4fe",
+    ...vars,
+    fullURL,
   };
 
-  const result = fetch(process.env.REACT_APP_BASE_BACKEND_URL + "send", {
+  const result = fetch(process.env.REACT_APP_BASE_BACKEND_URL + "send/rsvp", {
     method: "POST",
     headers: {
       Accept: "application/json",
@@ -35,20 +22,8 @@ export const sendResponseEmail = (vars) => {
 export const sendConfirmationEmail = async (vars) => {
   const fullURL = `${process.env.REACT_APP_BASE_URL}/admin/${vars.secretUuid}`;
   var params = {
-    from: {
-      email: "noodle@noodleapp.cool",
-    },
-    personalizations: [
-      {
-        to: [{ email: vars.hostEmail }],
-        dynamic_template_data: {
-          name: vars.hostName,
-          eventName: vars.eventName,
-          eventAdminUrl: fullURL,
-        },
-      },
-    ],
-    template_id: "d-1c0fd3f9eb674287b5eb839deb958cf0",
+    ...vars,
+    fullURL,
   };
 
   const response = await fetch(


### PR DESCRIPTION
For added security, we should set the shape of the payload we send to sendgrid on the backend server we control.
This should do it, but it needs to be merged at about the same time as the [corresponding backend PR](https://github.com/rkaufman13/noodle-backend/pull/7).
