### PR TITLE
make active status responsive

### DIFF
--- a/src/AdminPage.js
+++ b/src/AdminPage.js
@@ -25,13 +25,15 @@ export const adminLoader = ({ params }) => {
 };
 
 const AdminChild = () => {
-  const [shareUrlVisible, setShareUrlVisible] = useState(false);
   const [closeModalVisible, setCloseModalVisible] = useState(false);
   const [deleteModalVisible, setDeleteModalVisible] = useState(false);
   const [emailModalVisible, setEmailModalVisible] = useState(false);
   const [successMessage, setSuccessMessage] = useState("");
   const [copyButtonText, setCopyButtonText] = useState("Copy Link");
+
   const [finalAdminEvent, eventKey] = useAsyncValue();
+
+  const [noodIsActive, setNoodIsActive] = useState(finalAdminEvent.active);
 
   if (!finalAdminEvent) {
     return (
@@ -50,18 +52,10 @@ const AdminChild = () => {
   const participants = reverseObject(finalAdminEvent);
   const datesArray = Object.keys(finalAdminEvent.dates);
 
-  const toggleShare = () => {
-    setShareUrlVisible(!shareUrlVisible);
-    if (shareUrlVisible) {
-      setCopyButtonText("Copy Link");
-    }
-  };
-
   const toggleClose = () => {
     setCloseModalVisible(!closeModalVisible);
     setDeleteModalVisible(false);
     setEmailModalVisible(false);
-    setSuccessMessage("Noodle successfully closed.");
     setTabFocus(".modal");
   };
 
@@ -82,6 +76,7 @@ const AdminChild = () => {
   const handleCloseEvent = () => {
     setCloseModalVisible(false);
     closeEvent(eventKey);
+    setNoodIsActive(false);
     clearTabFocus();
     setSuccessMessage("Noodle successfully closed.");
   };
@@ -110,8 +105,15 @@ const AdminChild = () => {
   return (
     <>
       <Helmet>
-        <title>Noodle Scheduling ~ {finalAdminEvent.eventname ?? "Untitled event"}</title>
-        <meta name="description" content={"Admin page for " + finalAdminEvent.eventname ?? "Admin page"} />
+        <title>
+          Noodle Scheduling ~ {finalAdminEvent.eventname ?? "Untitled event"}
+        </title>
+        <meta
+          name="description"
+          content={
+            "Admin page for " + finalAdminEvent.eventname ?? "Admin page"
+          }
+        />
       </Helmet>
       <div>
         <h1>{finalAdminEvent.eventname ?? "Untitled event"}</h1>
@@ -131,10 +133,8 @@ const AdminChild = () => {
       <div>
         <p>DO NOT LOSE THIS URL OR SHARE IT WITH ANYONE.</p>
       </div>
-      <div>
-        Your Nood is currently {finalAdminEvent.active ? "ACTIVE" : "CLOSED"}.{" "}
-      </div>
-      {finalAdminEvent.active && (
+      <div>Your Nood is currently {noodIsActive ? "ACTIVE" : "CLOSED"}. </div>
+      {noodIsActive && (
         <>
           <Stack>
             To get responses for your Nood, share this link with your friends.
@@ -156,7 +156,7 @@ const AdminChild = () => {
           <Button
             variant="primary"
             onClick={toggleClose}
-            disabled={finalAdminEvent.active === false}
+            disabled={noodIsActive === false}
             className="ms-auto"
           >
             Close Your Nood
@@ -173,7 +173,7 @@ const AdminChild = () => {
       </div>
       <hr className="p-2 invisible" />
       <div>
-        <h2>Your Nood So Far</h2>
+        <h2>Your Nood{noodIsActive && " So Far"}</h2>
         <DateTable
           participants={participants}
           dates={datesArray}


### PR DESCRIPTION
Adds a state variable to hold the `active` status of the current nood. This means that when a user closes a Nood, they see the correct UI immediately instead of waiting for page refresh