### PR TITLE
wrap dateTable in an overflow-scroll container

### DIFF
--- a/src/AdminPage.js
+++ b/src/AdminPage.js
@@ -174,25 +174,27 @@ const AdminChild = () => {
       <hr className="p-2 invisible" />
       <div>
         <h2>Your Nood{noodIsActive && " So Far"}</h2>
-        <DateTable
-          participants={participants}
-          dates={datesArray}
-          eventUUID={finalAdminEvent.uuid}
-        >
-          {Object.keys(participants).length > 0 ? (
-            <>
-              {" "}
-              <Participants
-                participants={participants}
-                dates={datesArray}
-                activePerson={null}
-              />
-              <BestDay dates={finalAdminEvent.dates} />
-            </>
-          ) : (
-            <EmptyEvent dates={finalAdminEvent.dates} />
-          )}
-        </DateTable>
+        <Stack className="overflow-auto container-lg">
+          <DateTable
+            participants={participants}
+            dates={datesArray}
+            eventUUID={finalAdminEvent.uuid}
+          >
+            {Object.keys(participants).length > 0 ? (
+              <>
+                {" "}
+                <Participants
+                  participants={participants}
+                  dates={datesArray}
+                  activePerson={null}
+                />
+                <BestDay dates={finalAdminEvent.dates} />
+              </>
+            ) : (
+              <EmptyEvent dates={finalAdminEvent.dates} />
+            )}
+          </DateTable>
+        </Stack>
       </div>
       {finalAdminEvent.hostEmail && (
         <>


### PR DESCRIPTION
Wraps DateTable in a container that causes horizontal overflow to scroll, to bring the behavior more in line with what we see on the EventPage.