### PR TITLE
Fix unique key browser warning for DayPicker

### DIFF
--- a/src/calendar/components/day_picker/day_picker.js
+++ b/src/calendar/components/day_picker/day_picker.js
@@ -126,7 +126,7 @@ export default function DayPicker({
                   }
 
                   return (
-                    <>
+                    <div key={object.date.dayOfYear}>
                       {!parentClassName.includes("hidden") ? (
                         <button
                           key={i}
@@ -151,7 +151,7 @@ export default function DayPicker({
                       ) : (
                         <span key={i} className={parentClassName}></span>
                       )}
-                    </>
+                    </div>
                   );
                 })}
               </div>


### PR DESCRIPTION
Just a mini-fix to clear the browser warning about unique keys for lists